### PR TITLE
Fixed arguments warning

### DIFF
--- a/lib/pod/command/spec/doc.rb
+++ b/lib/pod/command/spec/doc.rb
@@ -8,7 +8,7 @@ module Pod
           Opens the web documentation of the Pod with the given NAME.
         DESC
 
-        self.arguments = 'NAME'
+        self.arguments = [['NAME', :required]]
 
         def initialize(argv)
           @name = argv.shift_argument


### PR DESCRIPTION
CLAide changed the way arguments are defined.
Fix removes following warning:

```
[!] The specification of arguments as a string has been deprecated Pod::Command::Spec::Doc: `NAME`
```
